### PR TITLE
Changed second arg_node kind check to `elif`

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -125,8 +125,7 @@ def analyze_cxx_abi(view, start=None, length=None, task=None):
             if arg_nodes[-1].kind == 'builtin' and arg_nodes[-1].value == '...':
                 arg_nodes.pop()
                 var_arg = True
-
-            if arg_nodes[0].kind == 'builtin' and arg_nodes[0].value == 'void':
+            elif arg_nodes[0].kind == 'builtin' and arg_nodes[0].value == 'void':
                 arg_nodes = arg_nodes[1:]
 
             this_arg = False


### PR DESCRIPTION
Some functions I tested had an `arg_node` list size of 1, so the second
check for `builtin` and `void` would create an error.