### PR TITLE
Fix compatibility issue with new Binary Ninja API and avoid crashes accessing ilcall's 'params'

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -317,8 +317,12 @@ def analyze_cxx_abi(view, start=None, length=None, task=None):
 
         elif is_code and name_ast.kind == 'func':
             func = view.get_function_at(symbol.address)
-            demangled = ty_from_demangler_node(name_ast,
-                                               arg_count_hint=len(func.type.parameters))
+
+            ftype = getattr(func, 'type', None)
+            if ftype is None:
+                ftype = ftype.function_type
+            
+            demangled = ty_from_demangler_node(name_ast, arg_count_hint=len(ftype.parameters))
             if demangled is not None:
                 this_arg, ty, dtor_ctor = demangled
                 func.apply_auto_discovered_type(ty)

--- a/__init__.py
+++ b/__init__.py
@@ -336,7 +336,7 @@ def analyze_cxx_abi(view, start=None, length=None, task=None):
                         ast = parse_mangled(il_call.function.source_function.name)
                         if ast and is_ctor_or_dtor(ast):
                             continue
-                        if not il_call.params:
+                        if not hasattr(il_call, 'params') or not il_call.params:
                             continue
                         this = il_call.params[0]
                         class_type = func.parameter_vars[0].type

--- a/__init__.py
+++ b/__init__.py
@@ -318,7 +318,7 @@ def analyze_cxx_abi(view, start=None, length=None, task=None):
         elif is_code and name_ast.kind == 'func':
             func = view.get_function_at(symbol.address)
             demangled = ty_from_demangler_node(name_ast,
-                                               arg_count_hint=len(func.function_type.parameters))
+                                               arg_count_hint=len(func.type.parameters))
             if demangled is not None:
                 this_arg, ty, dtor_ctor = demangled
                 func.apply_auto_discovered_type(ty)


### PR DESCRIPTION
This pull request addresses a compatibility issue with the new Binary Ninja API version. In the previous version, the **function_type** field was used to retrieve the type of a function. However, in the new version, this field no longer exists.

To resolve this issue, the code has been modified to first check the **type** attribute. If it is not present, the code now falls back to using **function_type**.

Additionally, this pull request introduces a check for the params attribute of **ilcall** to prevent crashes. By verifying the existence of params, potential crashes resulting from its absence are now avoided.