### PR TITLE
Gracefully log local and closure object types

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -12,7 +12,9 @@ from binaryninja.enums import SymbolType, ReferenceType
 
 import sys
 import os.path
-sys.path.append(os.path.join(os.path.dirname(__file__), "itanium_demangler"))
+# Prepend so if the itanium-demangler package is installed elsewhere it doesn't 
+# interfere
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "itanium_demangler"))
 from itanium_demangler import Node, parse as parse_mangled, is_ctor_or_dtor
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -337,9 +337,15 @@ def analyze_cxx_abi(view, start=None, length=None, task=None):
                         except StopIteration:
                             continue
 
-                        # If the calling function is a ctor/dtor, it's probably running inherited constructors
-                        # so we shouldn't override the type
-                        ast = parse_mangled(il_call.function.source_function.name)
+                        try:
+                            # If the calling function is a ctor/dtor, it's 
+                            # probably running inherited constructors
+                            # so we shouldn't override the type
+                            ast = parse_mangled(il_call.function.source_function.name)
+                        except NotImplementedError as e:
+                            log.log_warn("Demangler feature missing on {}: {}".format(il_call.function.source_function.name, str(e)))
+                            demangler_failures += 1
+
                         if ast and is_ctor_or_dtor(ast):
                             continue
                         if not hasattr(il_call, 'params') or not il_call.params:

--- a/__init__.py
+++ b/__init__.py
@@ -381,7 +381,9 @@ class CxxAbiAnalysis(BackgroundTaskThread):
 
     def run(self):
         try:
+            state = self._view.begin_undo_actions()
             analyze_cxx_abi(self._view, task=self)
+            self._view.commit_undo_actions(state)
         finally:
             self.finish()
 

--- a/itanium_demangler/itanium_demangler/__init__.py
+++ b/itanium_demangler/itanium_demangler/__init__.py
@@ -711,7 +711,7 @@ def _parse_type(cursor):
     elif match.group('member_type') is not None:
         cls_ty = _parse_type(cursor)
         member_ty = _parse_type(cursor)
-        if member_ty.kind == 'func':
+        if member_ty is not None and member_ty.kind == 'func':
             kind = "method"
         else:
             kind = "data"
@@ -749,7 +749,9 @@ def _expand_template_args(func):
         if name_suffix.kind == 'tpl_args':
             tpl_args = name_suffix.value
             def mapper(node):
-                if node.kind == 'tpl_param' and node.value < len(tpl_args):
+                if node is None:
+                    return None
+                elif node.kind == 'tpl_param' and node.value < len(tpl_args):
                     return tpl_args[node.value]
                 return node.map(mapper)
             return mapper(func)
@@ -858,7 +860,9 @@ def _parse_mangled_name(cursor):
 
 def _expand_arg_packs(ast):
     def mapper(node):
-        if node.kind == 'tpl_args':
+        if node is None:
+            return None
+        elif node.kind == 'tpl_args':
             exp_args = []
             for arg in node.value:
                 if arg.kind in ['tpl_arg_pack', 'tpl_args']:
@@ -871,6 +875,7 @@ def _expand_arg_packs(ast):
             exp_arg_tys = []
             for arg_ty in node.arg_tys:
                 if arg_ty.kind == 'expand_arg_pack' and \
+                        arg_ty.value is not None and \
                         arg_ty.value.kind == 'rvalue' and \
                             arg_ty.value.value.kind in ['tpl_arg_pack', 'tpl_args']:
                     exp_arg_tys += arg_ty.value.value.value

--- a/itanium_demangler/itanium_demangler/__init__.py
+++ b/itanium_demangler/itanium_demangler/__init__.py
@@ -846,10 +846,13 @@ def _parse_mangled_name(cursor):
     if match is None:
         return None
     else:
+        cursor_position = cursor._pos
         special = _parse_special(cursor)
         if special is not None:
             return special
 
+        # Return the cursor position to it's previous state before continuing
+        cursor._pos = cursor_position
         return _parse_encoding(cursor)
 
 


### PR DESCRIPTION
Some small changes to gracefully fail on local names and closures. the closures were the ones causing me the most trouble.

I'm not completely sure about how I implemented the cursor position save in `itanium_demangler/itanium_demangler/__init__.py`? that appears counter to how the tool seems to work. I tried to look into it further to figure out how to gracefully fail out without consuming the string when `_parse_special` found a situation it couldn't handle but in the time (and attention) I have I was not able to figure out a more graceful way to do that.